### PR TITLE
Get rid of error message when function is reloaded

### DIFF
--- a/plugin/bclose.vim
+++ b/plugin/bclose.vim
@@ -1,6 +1,6 @@
 "here is a more exotic version of my original Kwbd script
 "delete the buffer; keep windows; create a scratch buffer if no buffers left
-function s:Kwbd(kwbdStage)
+function! s:Kwbd(kwbdStage)
   if(a:kwbdStage == 1)
     if(!buflisted(winbufnr(0)))
       bd!


### PR DESCRIPTION
When .vimrc is reloaded, vim generates an error because the function is
being redefined. Using function! instead of function tells vim that the
function can be safely reloaded. This stops vim from generating the
error message.
